### PR TITLE
Improve UI card component

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,4 +75,7 @@ dependencies {
 
     // Coil (Coroutines Image Loader)
     implementation(libs.coil.compose)
+
+    // Html parser (Used in image link extraction))
+    implementation(libs.jsoup)
 }

--- a/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
+++ b/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
@@ -104,6 +104,8 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+// Extract the HTML or BBCode image link and returns it to be displayed.
+// If no image is found in the description, it returns the game image.
 fun extractImageUrl(newsitem: Newsitem): String? {
     // 1. Parse for HTML <img> tags
     val doc = Jsoup.parse(newsitem.contents)

--- a/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
+++ b/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
@@ -1,5 +1,8 @@
 package marwen.gameid.gamenews
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -8,6 +11,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -86,7 +90,7 @@ class MainActivity : ComponentActivity() {
                         contentPadding = PaddingValues(16.dp)
                     ) {
                         items(newsList.size){ index ->
-                            Newsitem(newsList[index])
+                            Newsitem(newsList[index], context)
                             Spacer(modifier = Modifier.height(16.dp))
                         }
                     }
@@ -98,7 +102,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Newsitem(newsitem: Newsitem){
+fun Newsitem(newsitem: Newsitem, context: Context){
     val defaultImage = "https://steamcdn-a.akamaihd.net/steam/apps/" + newsitem.appid + "/header.jpg"
     val imageState = rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current).data(defaultImage)
@@ -106,10 +110,15 @@ fun Newsitem(newsitem: Newsitem){
     ).state
 
     Column(
-        modifier = Modifier.clip(RoundedCornerShape(20.dp))
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
             .height(300.dp)
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primaryContainer)
+            .clickable {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(newsitem.url))
+                context.startActivity(intent)
+            }
     ) {
         if (imageState is AsyncImagePainter.State.Error){
             Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
+++ b/app/src/main/java/marwen/gameid/gamenews/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
@@ -151,7 +152,9 @@ fun Newsitem(newsitem: Newsitem, context: Context){
         Text(
             modifier = Modifier.padding(horizontal = 16.dp),
             text = newsitem.contents,
-            fontSize = 13.sp
+            fontSize = 13.sp,
+            maxLines = 4, // Limit to 4 lines
+            overflow = TextOverflow.Ellipsis // ...
         )
 
 

--- a/app/src/main/java/marwen/gameid/gamenews/data/GameNewsRepositoryImpl.kt
+++ b/app/src/main/java/marwen/gameid/gamenews/data/GameNewsRepositoryImpl.kt
@@ -12,7 +12,7 @@ class GameNewsRepositoryImpl(
     override suspend fun getNewsList(): Flow<Result<List<Newsitem>>> {
         return flow {
             val newsFromApi = try {
-                api.getNewsList("730")  // Static App id of CS2
+                api.getNewsList("730")  // Static App id: CS2 730 | TF2 440 | Dota2 570
             } catch (e: IOException) {
                 e.printStackTrace()
                 emit(Result.Error(message = "Error loading Game News - IOException"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.6.0"
 coilCompose = "2.4.0"
 converterGson = "2.9.0"
+jsoup = "1.15.3"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
@@ -18,6 +19,7 @@ retrofit = "2.9.0"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Closes #1 
Old Component:
![original card](https://github.com/user-attachments/assets/e79fc8c6-37d1-49af-a88e-bd70c2f19a1b)
Actually the game news component needs more refinements:

- [x] Fix Description text overflow.
- [x] The game picture is already dynamic with appid, but not news specific.
- [x] Make the card clickable to see the full news article/blog.
- [ ] Description takes into account (or remove) html and Steam-style BBCode-like markup
New Component :
![afterFix](https://github.com/user-attachments/assets/d4b742d7-6803-4dad-87b7-7b0e134abfeb)
